### PR TITLE
Use virtool/workflow:1.0.0 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM virtool/workflow:nightly
+FROM virtool/workflow:1.0.0
 
 WORKDIR /app
 


### PR DESCRIPTION
Should resolve error on container start. The `create-sample` image is currently based on an old nightly.