### PR TITLE
fix: prevent failures due to excessive memory usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM virtool/workflow:2.1.0
+FROM virtool/workflow:2.1.1
 
 WORKDIR /app
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -254,7 +254,7 @@ pydantic = ">=1.8.2,<2.0.0"
 
 [[package]]
 name = "virtool-workflow"
-version = "2.1.0"
+version = "2.1.1"
 description = "A framework for developing bioinformatics workflows for Virtool."
 category = "main"
 optional = false
@@ -283,7 +283,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "39802294f8f2d73836d66b45f3add653e0d8b346f7e1381d3d360aee095b1c0c"
+content-hash = "47354ab73e839bea8a6de5c00741afb5f37c1ef65f1eb4ee29f18123714c63a3"
 
 [metadata.files]
 aiofiles = [
@@ -696,8 +696,8 @@ virtool-core = [
     {file = "virtool_core-0.4.0-py3-none-any.whl", hash = "sha256:3fd38d8d97c86ded02c1a9d3cfe770d459195084caba0223c6f247bbe8acafcc"},
 ]
 virtool-workflow = [
-    {file = "virtool-workflow-2.1.0.tar.gz", hash = "sha256:94c17e00ce3ae831f74f253b0fba924d428213f19bdf3bbd53218b65f5b056e7"},
-    {file = "virtool_workflow-2.1.0-py3-none-any.whl", hash = "sha256:4b85f8e2ec4b7d90cb19fb0b6ceed4a5ce2e8b23af17c88f3a6e4117b54ab121"},
+    {file = "virtool-workflow-2.1.1.tar.gz", hash = "sha256:d5a4881007adee762518ac07dd0601535bc28b0c7c65ce85aad4f010edbfb309"},
+    {file = "virtool_workflow-2.1.1-py3-none-any.whl", hash = "sha256:f6d3a72ea9001cff1baef383e013a3341eab67d348bc313fb9a3799e7414b8da"},
 ]
 yarl = [
     {file = "yarl-1.7.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f2a8508f7350512434e41065684076f640ecce176d262a7d54f0da41d99c5a95"},


### PR DESCRIPTION
Bug in `virtool-workflow`. Update to `2.1.1`.